### PR TITLE
Added Support for AWS API Gateway Rest API

### DIFF
--- a/docs/data-sources/aws_api_gateway_rest_api.md
+++ b/docs/data-sources/aws_api_gateway_rest_api.md
@@ -1,0 +1,30 @@
+# infracost_aws_api_gateway_rest_api
+
+Provides estimated usage data for an AWS API Gateway Rest API Requests.
+
+## Example Usage
+
+```hcl
+resource "aws_api_gateway_rest_api" "api" {
+  name = "my-rest-api"
+}
+
+data "infracost_aws_api_gateway_rest_api" "api_requests" {
+  resources = list(aws_api_gateway_rest_api.api.id)
+
+  monthly_requests {
+    value = 100000000
+  }
+}
+```
+
+## Argument Reference
+
+* `resources` - (Required) The ID of the Rest API.
+* `monthly_requests` - (Optional) The estimated monthly requests to the Rest API Gateway.
+
+### Usage values
+
+Each of the usage value blocks currently supports the following attributes:
+* `value` - (Optional) The estimated value.
+

--- a/infracost/data_source_aws_api_gateway_rest_api.go
+++ b/infracost/data_source_aws_api_gateway_rest_api.go
@@ -1,0 +1,15 @@
+package infracost
+
+import (
+    "github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsApiGatewayRestApi() *schema.Resource {
+    return &schema.Resource{
+        Read: dataSourceRead,
+        Schema: map[string]*schema.Schema{
+            "resources": resourcesSchema(),
+            "monthly_requests": usageSchema(),
+        },
+    }
+}

--- a/infracost/data_source_aws_api_gateway_rest_api_test.go
+++ b/infracost/data_source_aws_api_gateway_rest_api_test.go
@@ -1,0 +1,37 @@
+package infracost
+
+import (
+    "testing"
+
+    "github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAwsApiGatewayRestApi(t *testing.T) {
+    name := "data.infracost_aws_api_gateway_rest_api.my_api_requests"
+
+    resource.Test(t, resource.TestCase{
+        PreCheck:  func() {},
+        Providers: testAccProviders,
+        Steps: []resource.TestStep{
+            {
+                Config: testAwsApiGatewayConfig(),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    resource.TestCheckResourceAttr(name, "resources.#", "2"),
+                    testCheckResourceAttrValue(name, "monthly_requests", 1000000),
+                ),
+            },
+        },
+    })
+}
+
+func testAwsApiGatewayConfig() string {
+    return `
+		data "infracost_aws_api_gateway_rest_api" "my_api_requests" {
+			resources = list("my_rest_api_1", "my_rest_api_2")
+
+			monthly_requests {
+				value = 1000000
+			}
+		}
+	`
+}

--- a/infracost/data_source_aws_api_gateway_rest_api_test.go
+++ b/infracost/data_source_aws_api_gateway_rest_api_test.go
@@ -26,12 +26,11 @@ func TestAwsApiGatewayRestApi(t *testing.T) {
 
 func testAwsApiGatewayConfig() string {
     return `
-		data "infracost_aws_api_gateway_rest_api" "my_api_requests" {
-			resources = list("my_rest_api_1", "my_rest_api_2")
+        data "infracost_aws_api_gateway_rest_api" "my_api_requests" {
+            resources = list("my_rest_api_1", "my_rest_api_2")
 
-			monthly_requests {
-				value = 1000000
-			}
-		}
-	`
+            monthly_requests {
+              value = 1000000
+            }
+        }`
 }

--- a/infracost/provider.go
+++ b/infracost/provider.go
@@ -12,6 +12,7 @@ func Provider() terraform.ResourceProvider {
 			"infracost_aws_lambda_function": dataSourceAwsLambdaFunction(),
 			"infracost_aws_dynamodb_table":  dataSourceAwsDynamoDBTable(),
 			"infracost_aws_sqs_queue": dataSourceAwsSQSQueue(),
+			"infracost_aws_api_gateway_rest_api": dataSourceAwsApiGatewayRestApi(),
 		},
 	}
 }


### PR DESCRIPTION
This complements changes to infracost for https://github.com/infracost/infracost/pull/204. Provides the ability to estimate AWS API Gateway Rest API usage costs.

** Test Output **
```
 make testacc TESTARGS='-run=TestAwsApiGatewayRestApi'
TF_ACC=1 go test ./... -v -run=TestAwsApiGatewayRestApi -timeout 120m
?       github.com/infracost/terraform-provider-infracost       [no test files]
=== RUN   TestAwsApiGatewayRestApi
--- PASS: TestAwsApiGatewayRestApi (0.04s)
PASS
ok      github.com/infracost/terraform-provider-infracost/infracost     3.080s
```