### PR TITLE
Adds support for AWS Cloudwatch logs

### DIFF
--- a/docs/data-sources/aws_cloudwatch_log_group.md
+++ b/docs/data-sources/aws_cloudwatch_log_group.md
@@ -1,6 +1,6 @@
 # infracost_aws_cloudwatch_log_group
 
-Provides estimated usage data for an AWS Cloudwatch log group.
+Provides estimated usage data for an AWS CloudWatch log group.
 
 ## Example Usage
 
@@ -19,7 +19,7 @@ data "infracost_aws_cloudwatch_log_group" "logs" {
   monthly_gb_data_storage {
     value = 1000
   }
-  
+
   monthly_gb_data_scanned {
     value = 200
   }
@@ -28,10 +28,10 @@ data "infracost_aws_cloudwatch_log_group" "logs" {
 
 ## Argument Reference
 
-* `resources` - (Required) The IDs of the Cloudwatch logs log group to apply the estimated usage.
-* `monthly_gb_data_ingestion` - (Optional) The estimated GB of data ingested by Cloudwatch logs per month. 
-* `monthly_gb_data_storage` - (Optional) The estimated GB of data stored by Cloudwatch logs per month.
-* `monthly_gb_data_scanned` - (Optional) The estimated GB of data scanned by Cloudwatch logs insights per month.
+* `resources` - (Required) The IDs of the CloudWatch logs log group to apply the estimated usage.
+* `monthly_gb_data_ingestion` - (Optional) The estimated GB of data ingested by CloudWatch logs per month.
+* `monthly_gb_data_storage` - (Optional) The estimated GB of data stored by CloudWatch logs per month.
+* `monthly_gb_data_scanned` - (Optional) The estimated GB of data scanned by CloudWatch logs insights per month.
 
 ### Usage values
 

--- a/docs/data-sources/aws_cloudwatch_log_group.md
+++ b/docs/data-sources/aws_cloudwatch_log_group.md
@@ -1,0 +1,41 @@
+# infracost_aws_cloudwatch_log_group
+
+Provides estimated usage data for an AWS Cloudwatch log group.
+
+## Example Usage
+
+```hcl
+resource "aws_cloudwatch_log_group" "logs" {
+  name = "cloudwatch-log-group"
+}
+
+data "infracost_aws_cloudwatch_log_group" "logs" {
+  resources = list(aws_cloudwatch_log_group.logs.id)
+
+  monthly_gb_data_ingestion {
+    value = 1000
+  }
+
+  monthly_gb_data_storage {
+    value = 1000
+  }
+  
+  monthly_gb_data_scanned {
+    value = 200
+  }
+}
+```
+
+## Argument Reference
+
+* `resources` - (Required) The IDs of the Cloudwatch logs log group to apply the estimated usage.
+* `monthly_gb_data_ingestion` - (Optional) The estimated GB of data ingested by Cloudwatch logs per month. 
+* `monthly_gb_data_storage` - (Optional) The estimated GB of data stored by Cloudwatch logs per month.
+* `monthly_gb_data_scanned` - (Optional) The estimated GB of data scanned by Cloudwatch logs insights per month.
+
+### Usage values
+
+Each of the usage value blocks currently supports the following attributes:
+
+* `value` - (Optional) The estimated value.
+

--- a/infracost/data_source_aws_cloudwatch_log_group.go
+++ b/infracost/data_source_aws_cloudwatch_log_group.go
@@ -1,17 +1,17 @@
 package infracost
 
 import (
-    "github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func dataSourceAwsCloudwatchLogGroup() *schema.Resource {
-    return &schema.Resource{
-        Read: dataSourceRead,
-        Schema: map[string]*schema.Schema{
-            "resources": resourcesSchema(),
-            "monthly_gb_data_ingestion": usageSchema(),
-            "monthly_gb_data_storage": usageSchema(),
-            "monthly_gb_data_scanned": usageSchema(),
-        },
-    }
+	return &schema.Resource{
+		Read: dataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"resources":                 resourcesSchema(),
+			"monthly_gb_data_ingestion": usageSchema(),
+			"monthly_gb_data_storage":   usageSchema(),
+			"monthly_gb_data_scanned":   usageSchema(),
+		},
+	}
 }

--- a/infracost/data_source_aws_cloudwatch_log_group.go
+++ b/infracost/data_source_aws_cloudwatch_log_group.go
@@ -1,0 +1,17 @@
+package infracost
+
+import (
+    "github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsCloudwatchLogGroup() *schema.Resource {
+    return &schema.Resource{
+        Read: dataSourceRead,
+        Schema: map[string]*schema.Schema{
+            "resources": resourcesSchema(),
+            "monthly_gb_data_ingestion": usageSchema(),
+            "monthly_gb_data_storage": usageSchema(),
+            "monthly_gb_data_scanned": usageSchema(),
+        },
+    }
+}

--- a/infracost/data_source_aws_cloudwatch_log_group_test.go
+++ b/infracost/data_source_aws_cloudwatch_log_group_test.go
@@ -39,9 +39,9 @@ func testAwsCloudwatchLogGroupConfig() string {
 				value = 500
 			}
 
-            monthly_gb_data_scanned {
-                value = 100
-            }
+			monthly_gb_data_scanned {
+				value = 100
+			}
 		}
 	`
 }

--- a/infracost/data_source_aws_cloudwatch_log_group_test.go
+++ b/infracost/data_source_aws_cloudwatch_log_group_test.go
@@ -1,33 +1,33 @@
 package infracost
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAwsCloudwatchLogGroup(t *testing.T) {
-    name := "data.infracost_aws_cloudwatch_log_group.log_group"
+	name := "data.infracost_aws_cloudwatch_log_group.log_group"
 
-    resource.Test(t, resource.TestCase{
-        PreCheck:  func() {},
-        Providers: testAccProviders,
-        Steps: []resource.TestStep{
-            {
-                Config: testAwsCloudwatchLogGroupConfig(),
-                Check: resource.ComposeAggregateTestCheckFunc(
-                    resource.TestCheckResourceAttr(name, "resources.#", "2"),
-                    testCheckResourceAttrValue(name, "monthly_gb_data_ingestion", 1000),
-                    testCheckResourceAttrValue(name, "monthly_gb_data_storage", 500),
-                    testCheckResourceAttrValue(name, "monthly_gb_data_scanned", 100),
-                ),
-            },
-        },
-    })
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() {},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAwsCloudwatchLogGroupConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "resources.#", "2"),
+					testCheckResourceAttrValue(name, "monthly_gb_data_ingestion", 1000),
+					testCheckResourceAttrValue(name, "monthly_gb_data_storage", 500),
+					testCheckResourceAttrValue(name, "monthly_gb_data_scanned", 100),
+				),
+			},
+		},
+	})
 }
 
 func testAwsCloudwatchLogGroupConfig() string {
-    return `
+	return `
 		data "infracost_aws_cloudwatch_log_group" "log_group" {
 			resources = list("log_group_1", "log_group_2")
 

--- a/infracost/data_source_aws_cloudwatch_log_group_test.go
+++ b/infracost/data_source_aws_cloudwatch_log_group_test.go
@@ -1,0 +1,47 @@
+package infracost
+
+import (
+    "testing"
+
+    "github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAwsCloudwatchLogGroup(t *testing.T) {
+    name := "data.infracost_aws_cloudwatch_log_group.log_group"
+
+    resource.Test(t, resource.TestCase{
+        PreCheck:  func() {},
+        Providers: testAccProviders,
+        Steps: []resource.TestStep{
+            {
+                Config: testAwsCloudwatchLogGroupConfig(),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    resource.TestCheckResourceAttr(name, "resources.#", "2"),
+                    testCheckResourceAttrValue(name, "monthly_gb_data_ingestion", 1000),
+                    testCheckResourceAttrValue(name, "monthly_gb_data_storage", 500),
+                    testCheckResourceAttrValue(name, "monthly_gb_data_scanned", 100),
+                ),
+            },
+        },
+    })
+}
+
+func testAwsCloudwatchLogGroupConfig() string {
+    return `
+		data "infracost_aws_cloudwatch_log_group" "log_group" {
+			resources = list("log_group_1", "log_group_2")
+
+			monthly_gb_data_ingestion {
+				value = 1000
+			}
+			
+			monthly_gb_data_storage {
+				value = 500
+			}
+
+            monthly_gb_data_scanned {
+                value = 100
+            }
+		}
+	`
+}

--- a/infracost/provider.go
+++ b/infracost/provider.go
@@ -8,14 +8,14 @@ import (
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		DataSourcesMap: map[string]*schema.Resource{
-            "infracost_aws_api_gateway_rest_api": dataSourceAwsApiGatewayRestApi(),
-            "infracost_aws_apigatewayv2_api":     dataSourceAwsApiGatewayV2Api(),
-            "infracost_aws_codebuild_project":    dataSourceAwsCodebuildProject(),
-            "infracost_aws_dynamodb_table":       dataSourceAwsDynamoDBTable(),
-            "infracost_aws_cloudwatch_log_group": dataSourceAwsCloudwatchLogGroup(),
-            "infracost_aws_lambda_function":      dataSourceAwsLambdaFunction(),
-            "infracost_aws_nat_gateway":          dataSourceAwsNatGateway(),
-            "infracost_aws_sqs_queue":            dataSourceAwsSQSQueue(),
+			"infracost_aws_api_gateway_rest_api": dataSourceAwsApiGatewayRestApi(),
+			"infracost_aws_apigatewayv2_api":     dataSourceAwsApiGatewayV2Api(),
+			"infracost_aws_codebuild_project":    dataSourceAwsCodebuildProject(),
+			"infracost_aws_dynamodb_table":       dataSourceAwsDynamoDBTable(),
+			"infracost_aws_cloudwatch_log_group": dataSourceAwsCloudwatchLogGroup(),
+			"infracost_aws_lambda_function":      dataSourceAwsLambdaFunction(),
+			"infracost_aws_nat_gateway":          dataSourceAwsNatGateway(),
+			"infracost_aws_sqs_queue":            dataSourceAwsSQSQueue(),
 		},
 	}
 }

--- a/infracost/provider.go
+++ b/infracost/provider.go
@@ -12,6 +12,7 @@ func Provider() terraform.ResourceProvider {
             "infracost_aws_apigatewayv2_api":     dataSourceAwsApiGatewayV2Api(),
             "infracost_aws_codebuild_project":    dataSourceAwsCodebuildProject(),
             "infracost_aws_dynamodb_table":       dataSourceAwsDynamoDBTable(),
+            "infracost_aws_cloudwatch_log_group": dataSourceAwsCloudwatchLogGroup(),
             "infracost_aws_lambda_function":      dataSourceAwsLambdaFunction(),
             "infracost_aws_nat_gateway":          dataSourceAwsNatGateway(),
             "infracost_aws_sqs_queue":            dataSourceAwsSQSQueue(),


### PR DESCRIPTION
This compliments infracost pull request infracost/infracost#235. This provides the ability to estimate cloudwatch log ingestion, storage & analyze costs.

** Testing Output **
```
TF_ACC=1 go test ./... -v -run=TestAwsCloudwatchLogGroup -timeout 120m
?       github.com/infracost/terraform-provider-infracost       [no test files]
=== RUN   TestAwsCloudwatchLogGroup
--- PASS: TestAwsCloudwatchLogGroup (0.04s)
PASS
ok      github.com/infracost/terraform-provider-infracost/infracost     3.508s
```