### PR TITLE
Added support for SNS

### DIFF
--- a/docs/data-sources/aws_sns_topic.md
+++ b/docs/data-sources/aws_sns_topic.md
@@ -1,0 +1,36 @@
+# infracost_aws_sns_topic
+
+Provides estimated usage data for an AWS SNS Topic Requests.
+
+## Example Usage
+
+```hcl
+resource "aws_sns_topic" "sns_topic" {
+  name = "sns-topic"
+}
+
+data "infracost_aws_sns_queue" "costs" {
+  resources = list(aws_sns_topic.topic.id,)
+
+  monthly_requests {
+    value = 1000000
+  }
+  
+  request_size {
+    value = 64
+  }
+
+}
+```
+
+## Argument Reference
+
+* `resources` - (Required) The IDs of the SNS Queues to apply the estimated usage.
+* `monthly_requests` - (Optional) The estimated monthly requests to SNS.
+* `request_size` - (Optional) The size of the requests to SNS, SNS bills in 64KB chunks. So if you process 1,000,000 requests at 128KB you pay for 2,000,000 requests.
+
+### Usage values
+
+Each of the usage value blocks currently supports the following attributes:
+* `value` - (Optional) The estimated value.
+

--- a/docs/data-sources/aws_sns_topic.md
+++ b/docs/data-sources/aws_sns_topic.md
@@ -25,7 +25,7 @@ data "infracost_aws_sns_queue" "costs" {
 
 ## Argument Reference
 
-* `resources` - (Required) The IDs of the SNS Queues to apply the estimated usage.
+* `resources` - (Required) The IDs of the SNS Topic to apply the estimated usage.
 * `monthly_requests` - (Optional) The estimated monthly requests to SNS.
 * `request_size` - (Optional) The size of the requests to SNS, SNS bills in 64KB chunks. So if you process 1,000,000 requests at 128KB you pay for 2,000,000 requests.
 

--- a/docs/data-sources/aws_sns_topic_subscription.md
+++ b/docs/data-sources/aws_sns_topic_subscription.md
@@ -1,6 +1,6 @@
 # infracost_aws_sns_topic_subscription
 
-Provides estimated usage data for an AWS SNS Topic Requests.
+Provides estimated usage data for an AWS SNS Topic Subscription Requests.
 
 ## Example Usage
 
@@ -28,7 +28,7 @@ data "infracost_aws_sns_topic_subscription" "costs" {
 
 ## Argument Reference
 
-* `resources` - (Required) The IDs of the SNS Queues to apply the estimated usage.
+* `resources` - (Required) The IDs of the SNS Topic to apply the estimated usage.
 * `monthly_requests` - (Optional) The estimated monthly requests to SNS.
 * `request_size` - (Optional) The size of the requests to SNS, SNS bills in 64KB chunks. So if you process 1,000,000 requests at 128KB you pay for 2,000,000 requests.
 

--- a/docs/data-sources/aws_sns_topic_subscription.md
+++ b/docs/data-sources/aws_sns_topic_subscription.md
@@ -1,0 +1,39 @@
+# infracost_aws_sns_topic_subscription
+
+Provides estimated usage data for an AWS SNS Topic Requests.
+
+## Example Usage
+
+```hcl
+resource "aws_sns_topic_subscription" "sns_subscription" {
+  name = "sns-topic"
+  endpointType = "HTTP"
+  topic_arn = "aws_sns_topic.topic.arn"
+  endpoint = "my-http-sns-endpoint" 
+}
+
+data "infracost_aws_sns_topic_subscription" "costs" {
+  resources = list(aws_sns_topic_subscription.sns_subscription.id,)
+
+  monthly_requests {
+    value = 1000000
+  }
+  
+  request_size {
+    value = 64
+  }
+
+}
+```
+
+## Argument Reference
+
+* `resources` - (Required) The IDs of the SNS Queues to apply the estimated usage.
+* `monthly_requests` - (Optional) The estimated monthly requests to SNS.
+* `request_size` - (Optional) The size of the requests to SNS, SNS bills in 64KB chunks. So if you process 1,000,000 requests at 128KB you pay for 2,000,000 requests.
+
+### Usage values
+
+Each of the usage value blocks currently supports the following attributes:
+* `value` - (Optional) The estimated value.
+

--- a/infracost/data_source_aws_sns_topic.go
+++ b/infracost/data_source_aws_sns_topic.go
@@ -8,9 +8,9 @@ func dataSourceAwsSNSTopic() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceRead,
 		Schema: map[string]*schema.Schema{
-			"resources": resourcesSchema(),
+			"resources":        resourcesSchema(),
 			"monthly_requests": usageSchema(),
-			"request_size": usageSchema(),
+			"request_size":     usageSchema(),
 		},
 	}
 }

--- a/infracost/data_source_aws_sns_topic.go
+++ b/infracost/data_source_aws_sns_topic.go
@@ -1,0 +1,16 @@
+package infracost
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsSNSTopic() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"resources": resourcesSchema(),
+			"monthly_requests": usageSchema(),
+			"request_size": usageSchema(),
+		},
+	}
+}

--- a/infracost/data_source_aws_sns_topic_subscription.go
+++ b/infracost/data_source_aws_sns_topic_subscription.go
@@ -1,0 +1,16 @@
+package infracost
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsSNSTopicSubscription() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"resources": resourcesSchema(),
+			"monthly_requests": usageSchema(),
+			"request_size": usageSchema(),
+		},
+	}
+}

--- a/infracost/data_source_aws_sns_topic_subscription.go
+++ b/infracost/data_source_aws_sns_topic_subscription.go
@@ -8,9 +8,9 @@ func dataSourceAwsSNSTopicSubscription() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceRead,
 		Schema: map[string]*schema.Schema{
-			"resources": resourcesSchema(),
+			"resources":        resourcesSchema(),
 			"monthly_requests": usageSchema(),
-			"request_size": usageSchema(),
+			"request_size":     usageSchema(),
 		},
 	}
 }

--- a/infracost/data_source_aws_sns_topic_subscription_test.go
+++ b/infracost/data_source_aws_sns_topic_subscription_test.go
@@ -1,0 +1,42 @@
+package infracost
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAwsSNSTopicSubscription(t *testing.T) {
+	name := "data.infracost_aws_sns_topic_subscription.sns_subscription"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() {},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAwsSNSTopicSubscriptionConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "resources.#", "2"),
+					testCheckResourceAttrValue(name, "monthly_requests", 1000000),
+					testCheckResourceAttrValue(name, "request_size", 64),
+				),
+			},
+		},
+	})
+}
+
+func testAwsSNSTopicSubscriptionConfig() string {
+	return `
+		data "infracost_aws_sns_topic_subscription" "sns_subscription" {
+			resources = list("sns_topic_subscription_1", "sns_topic_subscription_2")
+
+			monthly_requests {
+				value = 1000000
+			}
+			
+			request_size {
+				value = 64
+			}
+		}
+	`
+}

--- a/infracost/data_source_aws_sns_topic_test.go
+++ b/infracost/data_source_aws_sns_topic_test.go
@@ -1,0 +1,42 @@
+package infracost
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAwsSNSTopic(t *testing.T) {
+	name := "data.infracost_aws_sns_topic.sns_topic"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() {},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAwsSNSTopicConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "resources.#", "2"),
+					testCheckResourceAttrValue(name, "monthly_requests", 1000000),
+					testCheckResourceAttrValue(name, "request_size", 64),
+				),
+			},
+		},
+	})
+}
+
+func testAwsSNSTopicConfig() string {
+	return `
+		data "infracost_aws_sns_topic" "sns_topic" {
+			resources = list("sns_topic_1", "sns_topic_2")
+
+			monthly_requests {
+				value = 1000000
+			}
+			
+			request_size {
+				value = 64
+			}
+		}
+	`
+}

--- a/infracost/provider.go
+++ b/infracost/provider.go
@@ -8,15 +8,15 @@ import (
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		DataSourcesMap: map[string]*schema.Resource{
-			"infracost_aws_api_gateway_rest_api": dataSourceAwsApiGatewayRestApi(),
-			"infracost_aws_apigatewayv2_api":     dataSourceAwsApiGatewayV2Api(),
-			"infracost_aws_codebuild_project":    dataSourceAwsCodebuildProject(),
-			"infracost_aws_dynamodb_table":       dataSourceAwsDynamoDBTable(),
-			"infracost_aws_cloudwatch_log_group": dataSourceAwsCloudwatchLogGroup(),
-			"infracost_aws_lambda_function":      dataSourceAwsLambdaFunction(),
-			"infracost_aws_nat_gateway":          dataSourceAwsNatGateway(),
-			"infracost_aws_sqs_queue":            dataSourceAwsSQSQueue(),
-			"infracost_aws_sns_topic":             dataSourceAwsSNSTopic(),
+			"infracost_aws_api_gateway_rest_api":   dataSourceAwsApiGatewayRestApi(),
+			"infracost_aws_apigatewayv2_api":       dataSourceAwsApiGatewayV2Api(),
+			"infracost_aws_codebuild_project":      dataSourceAwsCodebuildProject(),
+			"infracost_aws_dynamodb_table":         dataSourceAwsDynamoDBTable(),
+			"infracost_aws_cloudwatch_log_group":   dataSourceAwsCloudwatchLogGroup(),
+			"infracost_aws_lambda_function":        dataSourceAwsLambdaFunction(),
+			"infracost_aws_nat_gateway":            dataSourceAwsNatGateway(),
+			"infracost_aws_sqs_queue":              dataSourceAwsSQSQueue(),
+			"infracost_aws_sns_topic":              dataSourceAwsSNSTopic(),
 			"infracost_aws_sns_topic_subscription": dataSourceAwsSNSTopicSubscription(),
 		},
 	}

--- a/infracost/provider.go
+++ b/infracost/provider.go
@@ -16,6 +16,8 @@ func Provider() terraform.ResourceProvider {
 			"infracost_aws_lambda_function":      dataSourceAwsLambdaFunction(),
 			"infracost_aws_nat_gateway":          dataSourceAwsNatGateway(),
 			"infracost_aws_sqs_queue":            dataSourceAwsSQSQueue(),
+			"infracost_aws_sns_topic":             dataSourceAwsSNSTopic(),
+			"infracost_aws_sns_topic_subscription": dataSourceAwsSNSTopicSubscription(),
 		},
 	}
 }

--- a/infracost/provider.go
+++ b/infracost/provider.go
@@ -15,9 +15,10 @@ func Provider() terraform.ResourceProvider {
 			"infracost_aws_cloudwatch_log_group":   dataSourceAwsCloudwatchLogGroup(),
 			"infracost_aws_lambda_function":        dataSourceAwsLambdaFunction(),
 			"infracost_aws_nat_gateway":            dataSourceAwsNatGateway(),
-			"infracost_aws_sqs_queue":              dataSourceAwsSQSQueue(),
 			"infracost_aws_sns_topic":              dataSourceAwsSNSTopic(),
 			"infracost_aws_sns_topic_subscription": dataSourceAwsSNSTopicSubscription(),
+			"infracost_aws_sqs_queue":              dataSourceAwsSQSQueue(),
+
 		},
 	}
 }


### PR DESCRIPTION
This complements changes to infracost for https://github.com/infracost/infracost/pull/260. Provides the ability to estimate AWS SNS Topic & SNS Topic SubscriptionI usage costs.


**Test output**
```
TF_ACC=1 go test ./... -v -run=TestAwsSNSTopic -timeout 120m
?       github.com/infracost/terraform-provider-infracost       [no test files]
=== RUN   TestAwsSNSTopicSubscription
--- PASS: TestAwsSNSTopicSubscription (0.04s)
=== RUN   TestAwsSNSTopic
--- PASS: TestAwsSNSTopic (0.04s)
PASS
ok      github.com/infracost/terraform-provider-infracost/infracost     4.494s
```