### PR TITLE
Added Support for ECR Repository

### DIFF
--- a/docs/data-sources/aws_ecr_repository.md
+++ b/docs/data-sources/aws_ecr_repository.md
@@ -1,0 +1,30 @@
+# infracost_aws_ecr_repository
+
+Provides estimated usage data for an AWS ECR repository Requests.
+
+## Example Usage
+
+```hcl
+resource "aws_ecr_repository" "repo" {
+  name = "ecr-repo"
+}
+
+data "infracost_aws_ecr_repository" "costs" {
+  resources = list(aws_ecr_repository.repo.id)
+
+  storage_size {
+    value = 1
+  }
+}
+```
+
+## Argument Reference
+
+* `resources` - (Required) The IDs of the ECR Repository to apply the estimated usage.
+* `storage` - (Optional) The estimated monthly ECR repository storage usage.
+
+### Usage values
+
+Each of the usage value blocks currently supports the following attributes:
+* `value` - (Optional) The estimated value.
+

--- a/infracost/data_source_aws_ecr_repository.go
+++ b/infracost/data_source_aws_ecr_repository.go
@@ -1,0 +1,15 @@
+package infracost
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsECRRepository() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"resources":        resourcesSchema(),
+			"storage_size":     usageSchema(),
+		},
+	}
+}

--- a/infracost/data_source_aws_ecr_repository_test.go
+++ b/infracost/data_source_aws_ecr_repository_test.go
@@ -1,0 +1,37 @@
+package infracost
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAwsECRRepository(t *testing.T) {
+	name := "data.infracost_aws_ecr_repository.ecr_repository"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() {},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAwsECRRepositoryConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "resources.#", "2"),
+					testCheckResourceAttrValue(name, "storage_size", 100000),
+				),
+			},
+		},
+	})
+}
+
+func testAwsECRRepositoryConfig() string {
+	return `
+		data "infracost_aws_ecr_repository" "ecr_repository" {
+			resources = list("ecr_repo_1", "ecr_repo_2")
+
+			storage_size {
+				value = 100000
+			}
+		}
+	`
+}

--- a/infracost/provider.go
+++ b/infracost/provider.go
@@ -13,6 +13,7 @@ func Provider() terraform.ResourceProvider {
 			"infracost_aws_codebuild_project":    dataSourceAwsCodebuildProject(),
 			"infracost_aws_dynamodb_table":       dataSourceAwsDynamoDBTable(),
 			"infracost_aws_cloudwatch_log_group": dataSourceAwsCloudwatchLogGroup(),
+			"infracost_aws_ecr_repository":       dataSourceAwsECRRepository(),
 			"infracost_aws_lambda_function":      dataSourceAwsLambdaFunction(),
 			"infracost_aws_nat_gateway":          dataSourceAwsNatGateway(),
 			"infracost_aws_sqs_queue":            dataSourceAwsSQSQueue(),


### PR DESCRIPTION
This complements changes to infracost for infracost/infracost#262. Provides the ability to estimate AWS ECR Repository storage costs.

** Test output **

```
TF_ACC=1 go test ./... -v -run=TestAwsECRRepository -timeout 120m
?       github.com/infracost/terraform-provider-infracost       [no test files]
=== RUN   TestAwsECRRepository
--- PASS: TestAwsECRRepository (0.04s)
PASS
ok      github.com/infracost/terraform-provider-infracost/infracost     4.141s
```