### PR TITLE
Added support for VPN TGW Attachments.

### DIFF
--- a/docs/data-sources/aws_vpn_connection.md
+++ b/docs/data-sources/aws_vpn_connection.md
@@ -1,0 +1,32 @@
+# infracost_aws_vpn_connection
+
+Provides estimated usage data for an AWS VPN Transit gateway data processing.
+
+## Example Usage
+
+```hcl
+resource "aws_vpn_connection" "transit" {
+  customer_gateway_id = "my-cgw-id"
+  transit_gateway_id = "my-tgw-id"
+  type = "ipsec.1"
+}
+
+data "infracost_aws_vpn_connection" "vpn_transit_costs" {
+  resources = list(aws_vpn_connection.transit.id)
+
+  monthly_gb_data_processed {
+    value = 100
+  }
+}
+```
+
+## Argument Reference
+
+* `resources` - (Required) The IDs of the VPN connections to apply the estimated usage.
+* `monthly_gb_data_processed` - (Optional) The estimated monthly data processed through a transit gateway attached to your VPN Connection.
+
+### Usage values
+
+Each of the usage value blocks currently supports the following attributes:
+* `value` - (Optional) The estimated value.
+

--- a/docs/data-sources/aws_vpn_connection.md
+++ b/docs/data-sources/aws_vpn_connection.md
@@ -1,6 +1,6 @@
 # infracost_aws_vpn_connection
 
-Provides estimated usage data for an AWS VPN Transit gateway data processing.
+Provides estimated data processing costs for an AWS VPN Transit gateway attachment.
 
 ## Example Usage
 

--- a/infracost/data_source_aws_vpn_connection.go
+++ b/infracost/data_source_aws_vpn_connection.go
@@ -1,0 +1,15 @@
+package infracost
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsVPNConnection() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"resources":                 resourcesSchema(),
+			"monthly_gb_data_processed": usageSchema(),
+		},
+	}
+}

--- a/infracost/data_source_aws_vpn_connection_test.go
+++ b/infracost/data_source_aws_vpn_connection_test.go
@@ -1,0 +1,37 @@
+package infracost
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAwsVPNConnection(t *testing.T) {
+	name := "data.infracost_aws_vpn_connection.vpn_connection"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() {},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAwsVPNConnectionConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "resources.#", "2"),
+					testCheckResourceAttrValue(name, "monthly_gb_data_processed", 100),
+				),
+			},
+		},
+	})
+}
+
+func testAwsVPNConnectionConfig() string {
+	return `
+		data "infracost_aws_vpn_connection" "vpn_connection" {
+			resources = list("vpn_connection_1", "vpn_connection_2")
+
+			monthly_gb_data_processed {
+				value = 100
+			}
+		}
+	`
+}

--- a/infracost/provider.go
+++ b/infracost/provider.go
@@ -16,6 +16,7 @@ func Provider() terraform.ResourceProvider {
 			"infracost_aws_lambda_function":      dataSourceAwsLambdaFunction(),
 			"infracost_aws_nat_gateway":          dataSourceAwsNatGateway(),
 			"infracost_aws_sqs_queue":            dataSourceAwsSQSQueue(),
+			"infracost_aws_vpn_connection":       dataSourceAwsVPNConnection(),
 		},
 	}
 }


### PR DESCRIPTION
This complements changes to infracost for infracost/infracost#265. Provides the ability to estimate TGW data processing for VPNs that are attached to a Transit gateway.

**Test Output**:
```
 make testacc TESTARGS='-run=TestAwsVPNConnection'
TF_ACC=1 go test ./... -v -run=TestAwsVPNConnection -timeout 120m
?       github.com/infracost/terraform-provider-infracost       [no test files]
=== RUN   TestAwsVPNConnection
--- PASS: TestAwsVPNConnection (0.04s)
PASS
ok      github.com/infracost/terraform-provider-infracost/infracost     2.948s
```
