### PR TITLE
Added support for VPC Endpoint data processing

### DIFF
--- a/docs/data-sources/aws_vpc_endpoint.md
+++ b/docs/data-sources/aws_vpc_endpoint.md
@@ -1,6 +1,6 @@
 # infracost_aws_vpc_endpoint
 
-Provides estimated data processing through an AWS VPC `Interface` or `GatewayLoadBalancer` endpoint.
+Provides estimated data processing costs through an AWS VPC `Interface` or `GatewayLoadBalancer` endpoint.
 
 ## Example Usage
 

--- a/docs/data-sources/aws_vpc_endpoint.md
+++ b/docs/data-sources/aws_vpc_endpoint.md
@@ -1,0 +1,31 @@
+# infracost_aws_vpc_endpoint
+
+Provides estimated data processing through an AWS VPC `Interface` or `GatewayLoadBalancer` endpoint.
+
+## Example Usage
+
+```hcl
+resource "aws_vpc_endpoint" "vpc_endpoint" {
+  vpc_id = "vpc-123456"
+  service_name = "my-vpc-endpoint-service"
+}
+
+data "infracost_aws_vpc_endpoint" "vpc_endpoint_costs" {
+  resources = list(aws_vpc_endpoint.vpc_endpoint.id)
+
+  monthly_gb_data_processed {
+    value = 1000
+  }
+}
+```
+
+## Argument Reference
+
+* `resources` - (Required) The IDs of the VPC Endpoint to apply the estimated dat processing cost.
+* `monthly_gb_data_processed` - (Optional) The estimated monthly data processing in GB.
+
+### Usage values
+
+Each of the usage value blocks currently supports the following attributes:
+* `value` - (Optional) The estimated value.
+

--- a/docs/data-sources/aws_vpc_endpoint.md
+++ b/docs/data-sources/aws_vpc_endpoint.md
@@ -21,11 +21,11 @@ data "infracost_aws_vpc_endpoint" "vpc_endpoint_costs" {
 
 ## Argument Reference
 
-* `resources` - (Required) The IDs of the VPC Endpoint to apply the estimated dat processing cost.
-* `monthly_gb_data_processed` - (Optional) The estimated monthly data processing in GB.
+* `resources` - (Required) The IDs of the VPC endpoint(s) to apply the estimated usage.
+* `monthly_gb_data_processed` - (Optional) The estimated GB of data processed by the VPC endpoint(s) per month.
 
 ### Usage values
 
 Each of the usage value blocks currently supports the following attributes:
-* `value` - (Optional) The estimated value.
 
+* `value` - (Optional) The estimated value.

--- a/infracost/data_source_aws_vpc_endpoint.go
+++ b/infracost/data_source_aws_vpc_endpoint.go
@@ -1,0 +1,15 @@
+package infracost
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsVPCEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"resources":                 resourcesSchema(),
+			"monthly_gb_data_processed": usageSchema(),
+		},
+	}
+}

--- a/infracost/data_source_aws_vpc_endpoint_test.go
+++ b/infracost/data_source_aws_vpc_endpoint_test.go
@@ -1,0 +1,37 @@
+package infracost
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAwsVPCEndpoint(t *testing.T) {
+	name := "data.infracost_aws_vpc_endpoint.vpc_endpoint"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() {},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAwsVPCEndpointConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "resources.#", "2"),
+					testCheckResourceAttrValue(name, "monthly_gb_data_processed", 1000),
+				),
+			},
+		},
+	})
+}
+
+func testAwsVPCEndpointConfig() string {
+	return `
+		data "infracost_aws_vpc_endpoint" "vpc_endpoint" {
+			resources = list("vpc_endpoint_1", "vpc_endpoint_2")
+
+			monthly_gb_data_processed {
+				value = 1000
+			}
+		}
+	`
+}

--- a/infracost/provider.go
+++ b/infracost/provider.go
@@ -16,6 +16,7 @@ func Provider() terraform.ResourceProvider {
 			"infracost_aws_lambda_function":      dataSourceAwsLambdaFunction(),
 			"infracost_aws_nat_gateway":          dataSourceAwsNatGateway(),
 			"infracost_aws_sqs_queue":            dataSourceAwsSQSQueue(),
+			"infracost_aws_vpc_endpoint":         dataSourceAwsVPCEndpoint(),
 		},
 	}
 }


### PR DESCRIPTION
This complements changes to infracost for infracost/infracost#264. Provides the ability to estimate AWS Endpoint data processing costs.

**Test Output**:

```
make testacc TESTARGS='-run=TestAwsVPCEndpoint'
TF_ACC=1 go test ./... -v -run=TestAwsVPCEndpoint -timeout 120m
?       github.com/infracost/terraform-provider-infracost       [no test files]
=== RUN   TestAwsVPCEndpoint
--- PASS: TestAwsVPCEndpoint (0.04s)
PASS
ok      github.com/infracost/terraform-provider-infracost/infracost     3.028s

```