### PR TITLE
Adds support for TGW attachment data processing

### DIFF
--- a/docs/data-sources/aws_dx_gateway_association.md
+++ b/docs/data-sources/aws_dx_gateway_association.md
@@ -1,0 +1,32 @@
+# infracost_aws_dx_gateway_association
+
+Provides estimated usage data for an AWS DX Gateway association.
+
+## Example Usage
+
+```hcl
+resource "aws_dx_gateway_association" "gateway" {
+    dx_gateway_id = "dx-123456"
+    associated_gateway_id = "tgw-123456"
+}
+
+data "infracost_aws_dx_gateway_association" "gateway" {
+  resources = list(aws_dx_gateway_association.gateway.id)
+
+  monthly_gb_data_processed {
+    value = 100
+  }
+}
+```
+
+## Argument Reference
+
+* `resources` - (Required) The IDs of the DX gateway association(s) to apply the estimated usage.
+* `monthly_gb_data_processed` - (Optional) The estimated GB of data processed by the DX gateway association per month.
+
+### Usage values
+
+Each of the usage value blocks currently supports the following attributes:
+
+* `value` - (Optional) The estimated value.
+

--- a/docs/data-sources/aws_ec2_transit_gateway_vpc_attachment.md
+++ b/docs/data-sources/aws_ec2_transit_gateway_vpc_attachment.md
@@ -1,0 +1,33 @@
+# infracost_aws_ec2_transit_gateway_vpc_attachment
+
+Provides estimated usage data for an AWS EC2 Transit Gateway attachment.
+
+## Example Usage
+
+```hcl
+resource "aws_ec2_transit_gateway_vpc_attachment" "vpc_attachment" {
+    subnet_ids = ["subnet-123456", "subnet-654321"]
+    transit_gateway_id = "tgw-123456"
+    vpc_id = "vpc-123456"
+}
+
+data "infracost_aws_ec2_transit_gateway_vpc_attachment" "vpc_attachment" {
+  resources = list(aws_ec2_transit_gateway_vpc_attachment.vpc_attachment.id)
+
+  monthly_gb_data_processed {
+    value = 100
+  }
+}
+```
+
+## Argument Reference
+
+* `resources` - (Required) The IDs of the EC2 transit gateway attachment(s) to apply the estimated usage.
+* `monthly_gb_data_processed` - (Optional) The estimated GB of data processed by the EC2 transit gateway attachment(s) per month.
+
+### Usage values
+
+Each of the usage value blocks currently supports the following attributes:
+
+* `value` - (Optional) The estimated value.
+

--- a/infracost/data_source_aws_dx_gateway_association.go
+++ b/infracost/data_source_aws_dx_gateway_association.go
@@ -1,0 +1,15 @@
+package infracost
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsDXGatewayAssociation() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"resources":        resourcesSchema(),
+			"monthly_gb_data_processed": usageSchema(),
+		},
+	}
+}

--- a/infracost/data_source_aws_dx_gateway_association_test.go
+++ b/infracost/data_source_aws_dx_gateway_association_test.go
@@ -1,0 +1,37 @@
+package infracost
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAwsDXGatewayAssociationQueue(t *testing.T) {
+	name := "data.infracost_aws_dx_gateway_association.dx_tgw_association"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() {},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAwsDXGatewayAssociationConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "resources.#", "2"),
+					testCheckResourceAttrValue(name, "monthly_gb_data_processed", 1000),
+				),
+			},
+		},
+	})
+}
+
+func testAwsDXGatewayAssociationConfig() string {
+	return `
+		data "infracost_aws_dx_gateway_association" "dx_tgw_association" {
+			resources = list("dx_tgw_association_1", "dx_tgw_association_2")
+
+			monthly_gb_data_processed {
+				value = 1000
+			}
+		}
+	`
+}

--- a/infracost/data_source_aws_ec2_transit_gateway_vpc_attachment.go
+++ b/infracost/data_source_aws_ec2_transit_gateway_vpc_attachment.go
@@ -1,0 +1,15 @@
+package infracost
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsEC2TransitGatewayVPCAttachment() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"resources":        resourcesSchema(),
+			"monthly_gb_data_processed": usageSchema(),
+		},
+	}
+}

--- a/infracost/data_source_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/infracost/data_source_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -1,0 +1,37 @@
+package infracost
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAwsEC2TransitGatewayVPCAttachment(t *testing.T) {
+	name := "data.infracost_aws_ec2_transit_gateway_vpc_attachment.ec2_tgw_vpc_attach"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() {},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAwsEC2TransitGatewayVPCAttachmentConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "resources.#", "2"),
+					testCheckResourceAttrValue(name, "monthly_db_data_processed", 1000),
+				),
+			},
+		},
+	})
+}
+
+func testAwsEC2TransitGatewayVPCAttachmentConfig() string {
+	return `
+		data "infracost_aws_ec2_transit_gateway_vpc_attachment" "ec2_tgw_vpc_attach" {
+			resources = list("ec2_tgw_vpc_attach_1", "ec2_tgw_vpc_attach_2")
+
+			monthly_gb_data_processed {
+				value = 1000
+			}
+		}
+	`
+}

--- a/infracost/provider.go
+++ b/infracost/provider.go
@@ -13,6 +13,8 @@ func Provider() terraform.ResourceProvider {
 			"infracost_aws_codebuild_project":    dataSourceAwsCodebuildProject(),
 			"infracost_aws_dynamodb_table":       dataSourceAwsDynamoDBTable(),
 			"infracost_aws_cloudwatch_log_group": dataSourceAwsCloudwatchLogGroup(),
+			"infracost_aws_dx_gateway_association": dataSourceAwsDXGatewayAssociation(),
+			"infracost_aws_ec2_transit_gateway_vpc_attachment": dataSourceAwsEC2TransitGatewayVPCAttachment(),
 			"infracost_aws_lambda_function":      dataSourceAwsLambdaFunction(),
 			"infracost_aws_nat_gateway":          dataSourceAwsNatGateway(),
 			"infracost_aws_sqs_queue":            dataSourceAwsSQSQueue(),


### PR DESCRIPTION
This complements changes to infracost for infracost/infracost#284. Provides the ability to estimate AWS transit gateway data processing costs.

**Test Output**:

```
make testacc TESTARGS='-run=TestAwsDXGatewayAssociation'
TF_ACC=1 go test ./... -v -run=TestAwsDXGatewayAssociation -timeout 120m
?       github.com/infracost/terraform-provider-infracost       [no test files]
=== RUN   TestAwsDXGatewayAssociationQueue
--- PASS: TestAwsDXGatewayAssociationQueue (0.04s)
PASS
ok      github.com/infracost/terraform-provider-infracost/infracost     3.609s
```

```
make testacc TESTARGS='-run=TestAwsEC2TransitVPCAttachment'
TF_ACC=1 go test ./... -v -run=TestAwsEC2TransitVPCAttachment -timeout 120m
?       github.com/infracost/terraform-provider-infracost       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/infracost/terraform-provider-infracost/infracost     0.442s [no tests to run]
```
